### PR TITLE
improving the compression ratio for Lzma mode

### DIFF
--- a/app/src/main/cpp/ABRecompressor/src/BlocksAndDirectoryInfo.cpp
+++ b/app/src/main/cpp/ABRecompressor/src/BlocksAndDirectoryInfo.cpp
@@ -45,11 +45,7 @@ BlocksAndDirectoryInfo::BlocksAndDirectoryInfo(Reader* reader, Header* header, b
 }
 
 ByteArr* BlocksAndDirectoryInfo::ToBytes(){
-    uint64_t size = 16 + 4 + 4 + 10 * BlocksInfoCount;
-    for (uint i = 0; i < DirectoryInfoCount; i++){
-        size += DirectoryInfos[i].GetSize();
-    }
-    ByteArr* result = new ByteArr(size);
+    ByteArr* result = new ByteArr(GetRawSize());
     memcpy(result->GetData(), UncompressedDataHash->GetData(), 16);
     Writer writer = Writer(result, 16);
     writer.WriteUInt32(BlocksInfoCount);
@@ -95,4 +91,12 @@ uint64_t BlocksAndDirectoryInfo::DataSize(){
         return size1;
     }
     throw std::runtime_error("Data size mismatch, for blocks is " + std::to_string(size1) + " while for cab is " + std::to_string(size2));
+}
+
+uint64_t BlocksAndDirectoryInfo::GetRawSize(){
+    uint64_t size = 16 + 4 + 4 + 10 * BlocksInfoCount;
+    for (uint i = 0; i < DirectoryInfoCount; i++){
+        size += DirectoryInfos[i].GetSize();
+    }
+    return size;
 }

--- a/app/src/main/cpp/ABRecompressor/src/BlocksAndDirectoryInfo.h
+++ b/app/src/main/cpp/ABRecompressor/src/BlocksAndDirectoryInfo.h
@@ -27,6 +27,7 @@ public:
     ByteArr* ToBytes();
     ByteArr* ToBytes(CompressionType compressionType);
     uint64_t DataSize();
+    uint64_t GetRawSize();
 };
 
 #endif // ABRECOMPRESSOR_BLOCKSANDDIRECTORYINFO_H

--- a/app/src/main/cpp/ABRecompressor/src/Compression.cpp
+++ b/app/src/main/cpp/ABRecompressor/src/Compression.cpp
@@ -79,6 +79,7 @@ ByteArr* Compress(CompressionType compressionType, byte* tocompressData, uint to
         lzma_stream strm = LZMA_STREAM_INIT;
         lzma_ret ret;
         lzma_options_lzma opt;
+        opt.dict_size = 0x200000;
         lzma_lzma_preset(&opt, LZMA_PRESET_EXTREME);
         ret = lzma_alone_encoder(&strm, &opt);
         if (ret != LZMA_OK) {

--- a/app/src/main/java/top/laoxin/modmanager/tools/AssetBundleJNI.kt
+++ b/app/src/main/java/top/laoxin/modmanager/tools/AssetBundleJNI.kt
@@ -1,5 +1,8 @@
 package top.laoxin.modmanager.tools
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
 /**
  * JNI interface for interacting with native AssetBundle library.
  */
@@ -14,30 +17,11 @@ object AssetBundleJNI {
     const val AB_COMPRESSION_LZ4: Char = 2.toChar()
     const val AB_COMPRESSION_LZ4HC: Char = 3.toChar()
 
-    /**
-     * Loads an AssetBundle from byte array data.
-     *
-     * @param data The byte array containing the AssetBundle data.
-     * @return A pointer to the native AssetBundle object.
-     * @throws RuntimeException if there is an error during loading.
-     */
     @Throws(RuntimeException::class)
-    external fun loadFromBytes(data: ByteArray?): Long
+    private external fun loadFromBytes(data: ByteArray?): Long
 
-    /**
-     * Compresses an AssetBundle to a byte array.
-     *
-     * @param bundlePtr Pointer to the native AssetBundle object.
-     * @param compressionType The compression type to use, which can be one of the following:
-     * - [AssetBundleJNI.AB_COMPRESSION_NONE]
-     * - [AssetBundleJNI.AB_COMPRESSION_LZMA]
-     * - [AssetBundleJNI.AB_COMPRESSION_LZ4]
-     * - [AssetBundleJNI.AB_COMPRESSION_LZ4HC]
-     * @return A byte array containing the compressed AssetBundle data.
-     * @throws RuntimeException if there is an error during compression.
-     */
     @Throws(RuntimeException::class)
-    external fun compressToBytes(bundlePtr: Long, compressionType: Char): ByteArray?
+    private external fun compressToBytes(bundlePtr: Long, compressionType: Char): ByteArray?
 
     /**
      * Gets the compression type of the AssetBundle.
@@ -52,4 +36,31 @@ object AssetBundleJNI {
      */
     @Throws(RuntimeException::class)
     external fun getCompressionType(bundlePtr: Long): Char
+
+    /**
+     * Asynchronously loads an AssetBundle from byte array data.
+     *
+     * @param data The byte array containing the AssetBundle data.
+     * @return A pointer to the native AssetBundle object.
+     * @throws RuntimeException if there is an error during loading.
+     */
+    suspend fun loadFromBytesAsync(data: ByteArray?): Long = withContext(Dispatchers.IO) {
+        loadFromBytes(data)
+    }
+
+    /**
+     * Asynchronously compresses an AssetBundle to a byte array.
+     *
+     * @param bundlePtr Pointer to the native AssetBundle object.
+     * @param compressionType The compression type to use, which can be one of the following:
+     * - [AssetBundleJNI.AB_COMPRESSION_NONE]
+     * - [AssetBundleJNI.AB_COMPRESSION_LZMA]
+     * - [AssetBundleJNI.AB_COMPRESSION_LZ4]
+     * - [AssetBundleJNI.AB_COMPRESSION_LZ4HC]
+     * @return A byte array containing the compressed AssetBundle data.
+     * @throws RuntimeException if there is an error during compression.
+     */
+    suspend fun compressToBytesAsync(bundlePtr: Long, compressionType: Char): ByteArray? = withContext(Dispatchers.IO) {
+        compressToBytes(bundlePtr, compressionType)
+    }
 }


### PR DESCRIPTION
https://github.com/AXiX-official/ABRecompressor/releases/tag/v1.1.0

用碧蓝航线的文件测试了一下，115个文件，服务器提供的本身就是LZ4HC压缩的，共124MB，LZMA压缩后73.5MB，在LZ4HC的基础上仍然有60%左右的压缩率